### PR TITLE
`count` が何故か 2191 or 0 で固定されて集計されてしまう問題を修正

### DIFF
--- a/src/frontend/lib/memory.ts
+++ b/src/frontend/lib/memory.ts
@@ -76,7 +76,9 @@ class AppStateManager {
   }
 
   updateState (newState: DeepPartial<AppState>) {
-    this.currentState = {
+    // NOTE: Vue の data は getter を使って構成されているので、プロパティにアクセスするタイミングによって値が変わってしまう。
+    // これでは集計上不都合なので、ここで一度 pure なオブジェクトに変換している。
+    this.currentState = JSON.parse(JSON.stringify({
       configInUse: {
         ...this.currentState.configInUse,
         ...newState.configInUse,
@@ -89,7 +91,7 @@ class AppStateManager {
       },
       countdownId: newState.countdownId ?? this.currentState.countdownId,
       count: newState.count ?? this.currentState.count,
-    }
+    }))
   }
 
   getCurrentState (): AppState {

--- a/src/frontend/lib/memory.ts
+++ b/src/frontend/lib/memory.ts
@@ -80,6 +80,8 @@ class AppStateManager {
       configInUse: {
         ...this.currentState.configInUse,
         ...newState.configInUse,
+        // Infinity は JSON に変換できないので -1 として扱う
+        maxLoop: newState.configInUse?.maxLoop === Infinity ? -1 : (newState.configInUse?.maxLoop ?? this.currentState.configInUse.maxLoop),
       },
       state: {
         ...this.currentState.state,

--- a/src/frontend/lib/memory.ts
+++ b/src/frontend/lib/memory.ts
@@ -164,7 +164,7 @@ class MemoryMeasurementScheduler {
 
     const scheduleMeasurement = () => {
       const interval = measurementInterval()
-      console.log('Scheduling memory measurement in ' + Math.round(interval / 1000) + ' seconds.')
+      console.log(`Scheduling memory measurement in ${Math.round(interval / 1000)} seconds (${new Date(Date.now() + interval).toLocaleString()}).`)
       window.setTimeout(() => {
         this.measureAndReportMemory()
         scheduleMeasurement()

--- a/src/frontend/pages/SimpleTimer.vue
+++ b/src/frontend/pages/SimpleTimer.vue
@@ -81,9 +81,7 @@ export default Vue.extend({
     configInUse: {
       handler (newConfigInUse): void {
         appStateManager.updateState({
-          // NOTE: Vue の data は getter を使って構成されているので、プロパティにアクセスするタイミングによって値が変わってしまう。
-          // これでは集計上不都合なので、pure なオブジェクトに変換してから渡すようにしている。
-          configInUse: JSON.parse(JSON.stringify(newConfigInUse)),
+          configInUse: newConfigInUse,
         })
       },
       deep: true,
@@ -91,9 +89,7 @@ export default Vue.extend({
     state: {
       handler (newState): void {
         appStateManager.updateState({
-          // NOTE: Vue の data は getter を使って構成されているので、プロパティにアクセスするタイミングによって値が変わってしまう。
-          // これでは集計上不都合なので、pure なオブジェクトに変換してから渡すようにしている。
-          state: JSON.parse(JSON.stringify(newState)),
+          state: newState,
         })
       },
       deep: true,
@@ -144,9 +140,7 @@ export default Vue.extend({
       }
     },
     onCountdownprogress (count): void {
-      appStateManager.updateState({
-        count,
-      })
+      appStateManager.updateState({ count })
     },
     onCountdownEnd (): void {
       this.state.counting = false


### PR DESCRIPTION
ref: #33 

- 何故か `count` が何故か 2191 or 0 で固定されて集計されてしまっている
- これだと今のタイマーの残り時間が分からないので、ちゃんと取得できるようにしたい
- 原因不明 & 手元で全く再現しないのでとりあえずそれっぽいパッチを当てて勘で直してみる