### PR TITLE
メモリ使用量送信毎にcontextIdが強制的に書き換わっていた問題を修正

### DIFF
--- a/src/frontend/lib/memory.ts
+++ b/src/frontend/lib/memory.ts
@@ -100,6 +100,7 @@ class AppStateManager {
 }
 
 export const appStateManager = new AppStateManager()
+const CONTEXT_ID = uuidv4()
 
 class MemoryMeasurementScheduler {
   appStateManager: AppStateManager;
@@ -127,7 +128,7 @@ class MemoryMeasurementScheduler {
         env: process.env.NODE_ENV || 'development',
         origin: location.origin,
         pathname: location.pathname,
-        contextId: uuidv4(),
+        contextId: CONTEXT_ID,
         timestamp: timestamp.toISOString(),
         elapsedTimeSinceContextCreated: timestamp.getTime() - this.timeOfContextCreated,
         memoryMeasurement,


### PR DESCRIPTION
ref: #33 

本来であれば `contextId` はページがロードされた時にだけ生成され直されるIdであったが、実装にミスがあってメモリ使用量を送信する際に毎回生成され直されるようになっていた。