### PR TITLE
メモリ集計するセッションを制限する

### DIFF
--- a/src/frontend/main.ts
+++ b/src/frontend/main.ts
@@ -11,7 +11,10 @@ import router from './router'
 import App from './App.vue'
 import { memoryMeasurementScheduler } from './lib/memory'
 
-memoryMeasurementScheduler.start()
+// 全ユーザのメモリ使用量を集計してしまうと、データが大量に送信されてしまい、
+// Netlify Functions の無料枠を食いつぶしてしまうので、30% のセッションを対象に
+// メモリ集計を ON にする
+if (Math.random() < 0.3) memoryMeasurementScheduler.start()
 
 Vue.use(VueRouter)
 Vue.use(MuseUI)

--- a/src/frontend/main.ts
+++ b/src/frontend/main.ts
@@ -12,9 +12,9 @@ import App from './App.vue'
 import { memoryMeasurementScheduler } from './lib/memory'
 
 // 全ユーザのメモリ使用量を集計してしまうと、データが大量に送信されてしまい、
-// Netlify Functions の無料枠を食いつぶしてしまうので、30% のセッションを対象に
+// Netlify Functions の無料枠を食いつぶしてしまうので、20% のセッションを対象に
 // メモリ集計を ON にする
-if (Math.random() < 0.3) memoryMeasurementScheduler.start()
+if (Math.random() < 0.2) memoryMeasurementScheduler.start()
 
 Vue.use(VueRouter)
 Vue.use(MuseUI)


### PR DESCRIPTION
ref: https://github.com/RNGeek/emtimer/issues/33

- 大量にメモリ使用量集計用のエンドポイントが叩かれて、Netlify Functions の無料枠を食いつぶしかけている
- このままだと無料枠を食いつぶして有料プランに自動的に切り替わってしまうので、メモリ使用量の集計対象を制限したい
- ひとまず20%のセッションを対象に集計するよう制限してみる