### PR TITLE
chore: uuidモジュールの代わりにcrypto.randomUUIDを使う

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "muse-ui": "^2.1.0",
     "tslib": "^1.8.1",
     "typescript": "^4.0.2",
-    "uuid": "^8.3.0",
     "vue": "^2.6.12",
     "vue-router": "^2.7.0",
     "vue-snotify": "^3.0.4",

--- a/src/frontend/lib/memory.ts
+++ b/src/frontend/lib/memory.ts
@@ -1,5 +1,4 @@
 import * as Bowser from 'bowser'
-import { v4 as uuidv4 } from 'uuid'
 
 export const INITIAL_CONFIG = {
   duration: 10 * 1000,
@@ -71,7 +70,7 @@ class AppStateManager {
       configInUse: { ...INITIAL_CONFIG },
       state: { ...INTIAL_STATE },
       count: INITIAL_COUNT,
-      countdownId: uuidv4(),
+      countdownId: crypto.randomUUID(),
     }
   }
 
@@ -100,7 +99,7 @@ class AppStateManager {
 }
 
 export const appStateManager = new AppStateManager()
-const CONTEXT_ID = uuidv4()
+const CONTEXT_ID = crypto.randomUUID()
 
 class MemoryMeasurementScheduler {
   appStateManager: AppStateManager;

--- a/src/frontend/pages/SimpleTimer.vue
+++ b/src/frontend/pages/SimpleTimer.vue
@@ -42,7 +42,6 @@ import ModeView from '../components/ModeView.vue'
 import SoundEffector from '../lib/sound-effector'
 import 'vue-snotify'
 import { INITIAL_CONFIG, INTIAL_STATE, appStateManager } from '../lib/memory'
-import { v4 as uuidv4 } from 'uuid'
 
 const genListener = (fn: () => void) => (e: KeyboardEvent) => {
   if (e.key === ' ') { // スペースが入力された場合
@@ -119,7 +118,7 @@ export default Vue.extend({
       this.state.counting = true
       this.state.loop = 0
       this.initForTimer0()
-      appStateManager.updateState({ countdownId: uuidv4() })
+      appStateManager.updateState({ countdownId: crypto.randomUUID() })
     },
     stop (): void {
       this.state.counting = false

--- a/yarn.lock
+++ b/yarn.lock
@@ -8890,7 +8890,7 @@ utils-merge@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
 
-uuid@^8.0.0, uuid@^8.3.0:
+uuid@^8.0.0:
   version "8.3.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.0.tgz#ab738085ca22dc9a8c92725e459b1d507df5d6ea"
   integrity sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ==


### PR DESCRIPTION
主要ブラウザがすべて `crypto.randomUUID` を実装するようになったので、ライブラリを使う必要性もなくなったと思って消しました。

https://developer.mozilla.org/ja/docs/Web/API/Crypto/randomUUID